### PR TITLE
Fixes invalid value for imshow origin kwarg

### DIFF
--- a/pynoddy/output.py
+++ b/pynoddy/output.py
@@ -577,7 +577,7 @@ class NoddyOutput(object):
         #plot section
         title = kwds.get("title", "Section in %s-direction, pos=%d" % (direction, cell_pos))
                 
-        im = ax.imshow(section_slice, interpolation='nearest', aspect=ve, cmap=cmap_type, origin = 'lower left')
+        im = ax.imshow(section_slice, interpolation='nearest', aspect=ve, cmap=cmap_type, origin = 'lower')
        
         if colorbar and 'ax' not in kwds and False: #disable - color bar is broken
 #            cbar = plt.colorbar(im)


### PR DESCRIPTION
Fixes a simple bug where the invalid input string "lower left" is passed to `matplotlib.imshow`'s `origin` kwarg.

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-79b9a5b9105d> in <module>
     23 exp.events
     24 
---> 25 exp.plot_section()

D:\coding\agile\pynoddy\pynoddy\experiment\__init__.py in plot_section(self, direction, position, **kwds)
    375             self.determine_model_stratigraphy()
    376             # tmp_out.plot_section(direction = direction, layer_labels = self.model_stratigraphy, **kwds)
--> 377             tmp_out.plot_section(direction=direction, **kwds)
    378 
    379     def plot_multiple_random(self, direction='y', position='center', **kwds):

D:\coding\agile\pynoddy\pynoddy\output.py in plot_section(self, direction, position, **kwds)
    578         title = kwds.get("title", "Section in %s-direction, pos=%d" % (direction, cell_pos))
    579 
--> 580         im = ax.imshow(section_slice, interpolation='nearest', aspect=ve, cmap=cmap_type, origin = 'lower left')
    581 
    582         if colorbar and 'ax' not in kwds and False: #disable - color bar is broken

~\anaconda3\envs\agile-webapp\lib\site-packages\matplotlib-3.3.0rc1-py3.7-win-amd64.egg\matplotlib\__init__.py in inner(ax, data, *args, **kwargs)
   1411     def inner(ax, *args, data=None, **kwargs):
   1412         if data is None:
-> 1413             return func(ax, *map(sanitize_sequence, args), **kwargs)
   1414 
   1415         bound = new_sig.bind(ax, *args, **kwargs)

~\anaconda3\envs\agile-webapp\lib\site-packages\matplotlib-3.3.0rc1-py3.7-win-amd64.egg\matplotlib\axes\_axes.py in imshow(self, X, cmap, norm, aspect, interpolation, alpha, vmin, vmax, origin, extent, filternorm, filterrad, resample, url, **kwargs)
   5517         im = mimage.AxesImage(self, cmap, norm, interpolation, origin, extent,
   5518                               filternorm=filternorm, filterrad=filterrad,
-> 5519                               resample=resample, **kwargs)
   5520 
   5521         im.set_data(X)

~\anaconda3\envs\agile-webapp\lib\site-packages\matplotlib-3.3.0rc1-py3.7-win-amd64.egg\matplotlib\image.py in __init__(self, ax, cmap, norm, interpolation, origin, extent, filternorm, filterrad, resample, **kwargs)
    904             filterrad=filterrad,
    905             resample=resample,
--> 906             **kwargs
    907         )
    908 

~\anaconda3\envs\agile-webapp\lib\site-packages\matplotlib-3.3.0rc1-py3.7-win-amd64.egg\matplotlib\image.py in __init__(self, ax, cmap, norm, interpolation, origin, filternorm, filterrad, resample, **kwargs)
    245         if origin is None:
    246             origin = mpl.rcParams['image.origin']
--> 247         cbook._check_in_list(["upper", "lower"], origin=origin)
    248         self.origin = origin
    249         self.set_filternorm(filternorm)

~\anaconda3\envs\agile-webapp\lib\site-packages\matplotlib-3.3.0rc1-py3.7-win-amd64.egg\matplotlib\cbook\__init__.py in _check_in_list(_values, **kwargs)
   2248             raise ValueError(
   2249                 "{!r} is not a valid value for {}; supported values are {}"
-> 2250                 .format(v, k, ', '.join(map(repr, values))))
   2251 
   2252 

ValueError: 'lower left' is not a valid value for origin; supported values are 'upper', 'lower'
```