### PR TITLE
OSError message if not finding noddy executable

### DIFF
--- a/pynoddy/__init__.py
+++ b/pynoddy/__init__.py
@@ -92,7 +92,11 @@ def compute_model(history, output_name, **kwds):
         elif np2 is not None:
             noddy_path = np2
         else:
-            raise OSError
+            raise OSError("""
+            Unable to find noddy executable. Make sure it's accessible either
+            through your PATH environment variable or its being passed as
+            keyword argument 'noddy_path' into 'pynoddy.compute_model()'.
+            """)
 
     if "verbose" in kwds and kwds['verbose']:
         out = "Running noddy executable at %s(.exe)\n" % noddy_path


### PR DESCRIPTION
I've added an error message to the OSError being raised when `compute_model()` is unable to find the noddy executable, as I was a bit dumbfounded when I first used noddy in a venv.