### PR TITLE
Experiment sim_type and NoddyOut faultblock reading

### DIFF
--- a/pynoddy/__init__.py
+++ b/pynoddy/__init__.py
@@ -92,7 +92,11 @@ def compute_model(history, output_name, **kwds):
         elif np2 is not None:
             noddy_path = np2
         else:
-            raise OSError
+            raise OSError("""
+            Unable to find noddy executable. Make sure it's accessible either
+            through your PATH environment variable or its being passed as
+            keyword argument 'noddy_path' into 'pynoddy.compute_model()'.
+            """)
 
     if "verbose" in kwds and kwds['verbose']:
         out = "Running noddy executable at %s(.exe)\n" % noddy_path

--- a/pynoddy/experiment/__init__.py
+++ b/pynoddy/experiment/__init__.py
@@ -487,6 +487,7 @@ class Experiment(pynoddy.history.NoddyHistory, pynoddy.output.NoddyOutput):
         """
         remove_tmp_files = kwds.get("remove_tmp_files", True)
         compute_output = kwds.get("compute_output", True)
+        sim_type = kwds.get("sim_type", "BLOCK")
         self.get_cube_size()
         self.get_extent()
         resolution = kwds.get("resolution", self.cube_size)
@@ -537,7 +538,7 @@ class Experiment(pynoddy.history.NoddyHistory, pynoddy.output.NoddyOutput):
         # 4. run noddy
         import pynoddy.output
 
-        pynoddy.compute_model(tmp_his_file, tmp_out_file, output=compute_output)
+        pynoddy.compute_model(tmp_his_file, tmp_out_file, output=compute_output, sim_type=sim_type)
         # 5. open output
         i = 0
         # if False:

--- a/pynoddy/output.py
+++ b/pynoddy/output.py
@@ -21,6 +21,7 @@ class NoddyOutput(object):
         self.basename = output_name
         self.load_model_info()
         self.load_geology()
+        self.load_faultblock()
         
     def __add__(self, other):
         """Define addition as addition of grid block values
@@ -163,8 +164,28 @@ class NoddyOutput(object):
                 
                 for l in reversed(lithos):
                     self.stratigraphy.append(l)
-                
-            
+
+    def load_faultblock(self):
+        """Load fault block from .g21 output file"""
+        try:
+            with open(self.basename + ".g21", "r") as f:
+                lines = f.readlines()
+        except FileNotFoundError:
+            return
+
+        splits = []
+        for line in lines:
+            if line == "\n":
+                continue
+            split = [int(entry) for entry in line.rstrip().split("\t")]
+            splits.append(split)
+
+        sections = []
+        for n in range(1, self.nz + 1):
+            sections.append(np.array(splits[(n - 1) * self.ny:n * self.ny]))
+
+        self.faultblock = np.array(sections).T
+
     def load_geology(self):
         """Load block geology ids from .g12 output file"""
         with open(self.basename + ".g12", "r") as f:

--- a/pynoddy/output.py
+++ b/pynoddy/output.py
@@ -184,7 +184,7 @@ class NoddyOutput(object):
         for n in range(1, self.nz + 1):
             sections.append(np.array(splits[(n - 1) * self.ny:n * self.ny]))
 
-        self.faultblock = np.array(sections).T
+        self.faultblock = np.flip(np.array(sections), axis=1).T
 
     def load_geology(self):
         """Load block geology ids from .g12 output file"""

--- a/pynoddy/output.py
+++ b/pynoddy/output.py
@@ -167,7 +167,8 @@ class NoddyOutput(object):
             
     def load_geology(self):
         """Load block geology ids from .g12 output file"""
-        f = open(self.basename + ".g12")
+        with open(self.basename + ".g12", "r") as f:
+            lines = f.readlines()
         method = 'standard' # standard method to read file
         # method = 'numpy'    # using numpy should be faster - but it messes up the order... possible to fix?
         if method == 'standard':
@@ -175,7 +176,7 @@ class NoddyOutput(object):
             j = 0
             k = 0
             self.block = np.ndarray((self.nx,self.ny,self.nz))
-            for line in f.readlines():
+            for line in lines:
                 if line == '\n':
                     # next z-slice
                     k += 1


### PR DESCRIPTION
* `Experiment.get_section` method was missing ability to pass `sim_type` kwarg to specify simulation type (e.g. "BLOCK", "TOPOLOGY").
* `NoddyOutput` class now attempts to read `.g21` output file to read in the fault block. Stores it in `NoddyOutput.faultblock` if successful. Fails quietly.

This allows the user to easily access the fault block array that is outputted by Noddy if `sim_type="TOPOLOGY"`. This is vital for creating ML training dataset labels for faults.

![grafik](https://user-images.githubusercontent.com/17277800/91302674-208eb700-e7a7-11ea-986a-df9cfd1acc14.png)


**Minor improvements:**
* Fixes unsafe `.g12` file loading in `NoddyOutput` by using context manager.
* Adds OSError if `pynoddy.compute_model` can't find Noddy executable.

